### PR TITLE
setTimeout example + tests 

### DIFF
--- a/src/wait.js
+++ b/src/wait.js
@@ -1,0 +1,11 @@
+const logger = require('./common/logger');
+
+const ms = async (duration = 0) => {
+  logger.info(`Starting to wait ${duration} ms.`);
+  await new Promise((resolve) => setTimeout(resolve, duration));
+  logger.info(`Completed waiting ${duration} ms.`);
+};
+
+module.exports = {
+  ms,
+};

--- a/test/wait.j.spec.js
+++ b/test/wait.j.spec.js
@@ -1,0 +1,39 @@
+describe('./src/wait.js', () => {
+  const mockLogger = {
+    info: jest.fn(),
+  };
+  jest.mock('@/src/common/logger.js', () => mockLogger);
+
+  describe('ms', () => {
+    // i had a hard time using jest.useFakeTimers to mock setTimeout
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+    setTimeoutSpy.mockImplementation((fn) => fn());
+
+    const wait = require('@/src/wait');
+
+    it('calls setTimeout with a time to wait', async () => {
+      // arrange
+      // jest's default timeout is 5000 ms, so let's set this
+      // longer so that any failure to mock will be apparent.
+      // jest.setTimeout is not valid here, increasing the timeout
+      // of this test would be trying to solve the wrong problem.
+      const msToWait = 6000;
+
+      // act
+      await wait.ms(msToWait);
+
+      // assert
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), msToWait);
+    });
+
+    it('calls setTimeout without a time to wait', async () => {
+      // act
+      await wait.ms();
+
+      // assert
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 0);
+    });
+  });
+});

--- a/test/wait.j.spec.js
+++ b/test/wait.j.spec.js
@@ -1,4 +1,4 @@
-describe('./src/wait.js', () => {
+describe('src/wait.js', () => {
   const mockLogger = {
     info: jest.fn(),
   };

--- a/test/wait.m.spec.js
+++ b/test/wait.m.spec.js
@@ -1,0 +1,43 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const wait = require('../src/wait');
+
+describe('./src/wait.js', () => {
+  let clock;
+  let setTimeoutSpy;
+  before(() => {
+    clock = sinon.useFakeTimers();
+    setTimeoutSpy = sinon.spy(clock, 'setTimeout');
+  });
+  afterEach(() => {
+    setTimeoutSpy.resetHistory();
+  });
+  after(() => {
+    clock.restore();
+  });
+
+  it('calls setTimeout with a time to wait', async () => {
+    // arrange
+    const msToWait = 6000;
+
+    // act
+    const responsePromise = wait.ms(msToWait);
+    clock.tick(msToWait);
+    await responsePromise;
+
+    // assert
+    sinon.assert.callCount(setTimeoutSpy, 1);
+    expect(setTimeoutSpy.calledWith(sinon.match.func, msToWait)).to.equal(true);
+  });
+
+  it('calls setTimeout with a default', async () => {
+    // act
+    const responsePromise = wait.ms();
+    clock.tick(10);
+    await responsePromise;
+
+    // assert
+    sinon.assert.callCount(setTimeoutSpy, 1);
+    expect(setTimeoutSpy.calledWith(sinon.match.func, 0)).to.equal(true);
+  });
+});

--- a/test/wait.m.spec.js
+++ b/test/wait.m.spec.js
@@ -2,16 +2,19 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const wait = require('../src/wait');
 
-describe('./src/wait.js', () => {
+describe('src/wait.js', () => {
   let clock;
   let setTimeoutSpy;
+
   before(() => {
     clock = sinon.useFakeTimers();
     setTimeoutSpy = sinon.spy(clock, 'setTimeout');
   });
+
   afterEach(() => {
     setTimeoutSpy.resetHistory();
   });
+
   after(() => {
     clock.restore();
   });

--- a/test/wait.m.spec.js
+++ b/test/wait.m.spec.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
+const logger = require('../src/common/logger');
 const wait = require('../src/wait');
 
 describe('src/wait.js', () => {
@@ -18,6 +19,8 @@ describe('src/wait.js', () => {
   after(() => {
     clock.restore();
   });
+
+  sinon.stub(logger, 'info');
 
   it('calls setTimeout with a time to wait', async () => {
     // arrange


### PR DESCRIPTION
## A summary of your update
- create a use case for setTimeout
- add tests for src using setTimeout which leverage jest's and sinon's tools for skipping the wait

## Results of `npm run lint`
```bash
john@jaw-ubuntu-vm:~/code/js-unit-test-examples$ npm run lint

> js-unit-test-examples@1.0.0 lint
> eslint ./

john@jaw-ubuntu-vm:~/code/js-unit-test-examples$
```

## Results of `npm run test:mocha` and `npm run test:jest`
```bash
john@jaw-ubuntu-vm:~/code/js-unit-test-examples$ npm run test:mocha

> js-unit-test-examples@1.0.0 test:mocha
> nyc mocha


  ✓ src/common/throws.js throws asserts an error was thrown: 1ms
  ✓ src/destructuring.js can mock the logger: 5ms
  ✓ src/common/logger.js logger should call console.error with args: 4ms
  ✓ src/common/logger.js logger should call console.warn with args: 1ms
  ✓ src/common/logger.js logger should call console.log with args: 0ms
  ✓ src/common/logger.js logger should call console.debug with args: 0ms
  ✓ src/wait.js calls setTimeout with a time to wait: 1ms
  ✓ src/wait.js calls setTimeout with a default: 0ms
  ✓ src/selfInvoking.js calls throws with an error message: 4ms
  ✓ src/selfInvoking.js does not call `throws` additional times: 0ms

  10 passing (385ms)

-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |                   
 src               |     100 |      100 |     100 |     100 |                   
  destructuring.js |     100 |      100 |     100 |     100 |                   
  selfInvoking.js  |     100 |      100 |     100 |     100 |                   
  wait.js          |     100 |      100 |     100 |     100 |                   
 src/common        |     100 |      100 |     100 |     100 |                   
  logger.js        |     100 |      100 |     100 |     100 |                   
  throws.js        |     100 |      100 |     100 |     100 |                   
-------------------|---------|----------|---------|---------|-------------------
john@jaw-ubuntu-vm:~/code/js-unit-test-examples$ npm run test:jest

> js-unit-test-examples@1.0.0 test:jest
> jest

 PASS  test/selfInvoking.j.spec.js
 PASS  test/common/logger.j.spec.js
 PASS  test/destructuring.j.spec.js
 PASS  test/wait.j.spec.js
 PASS  test/common/throws.j.spec.js
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |                   
 src               |     100 |      100 |     100 |     100 |                   
  destructuring.js |     100 |      100 |     100 |     100 |                   
  selfInvoking.js  |     100 |      100 |     100 |     100 |                   
  wait.js          |     100 |      100 |     100 |     100 |                   
 src/common        |     100 |      100 |     100 |     100 |                   
  logger.js        |     100 |      100 |     100 |     100 |                   
  throws.js        |     100 |      100 |     100 |     100 |                   
-------------------|---------|----------|---------|---------|-------------------

Test Suites: 5 passed, 5 total
Tests:       12 passed, 12 total
Snapshots:   0 total
Time:        0.66 s, estimated 1 s
Ran all test suites.
john@jaw-ubuntu-vm:~/code/js-unit-test-examples$ 
```

