### PR TITLE
Environment-aware code + tests (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Jest just handles it.
 
 I've seen Sinon be challenged with self-invoking code due to how modules are loaded and cached. Jest has features for module caching, making its tests more straightforward in this context.
 
+### `src/testAware.js`
+
+Ideally, application source code is not where environment selection is being managed. Environment-specific values should be provided by the build system and code should use the value provided irrespective of environment.
+
+Exceptions exist. For example, a native mobile app might use a compiler directive to expose UI testing hooks.
+
 ### `src/common/*.js`
 
 These set up problems, but themselves are not intended to be problematic. the interactions with the callees is the problematic part.

--- a/src/testAware.js
+++ b/src/testAware.js
@@ -1,0 +1,3 @@
+const getApiKey = () => (process.env.NODE_ENV === 'production' ? 'the production API key' : 'the development API key');
+
+module.exports = { getApiKey };

--- a/test/testAware.j.spec.js
+++ b/test/testAware.j.spec.js
@@ -1,0 +1,25 @@
+describe('src/testAware.js', () => {
+  const { getApiKey } = require('../src/testAware');
+
+  afterEach(() => {
+    process.env.NODE_ENV = undefined;
+  });
+  it('shows the test output when configured correctly', () => {
+    // arrange
+    process.env.NODE_ENV = 'production';
+
+    // act
+    const response = getApiKey();
+
+    // assert
+    expect(response).toEqual('the production API key');
+  });
+
+  it('shows unintended output when not configured', () => {
+    // act
+    const response = getApiKey();
+
+    // assert
+    expect(response).toEqual('the development API key');
+  });
+});

--- a/test/testAware.m.spec.js
+++ b/test/testAware.m.spec.js
@@ -1,0 +1,26 @@
+const { expect } = require('chai');
+const { getApiKey } = require('../src/testAware');
+
+describe('src/testAware.js', () => {
+  afterEach(() => {
+    process.env.NODE_ENV = undefined;
+  });
+  it('shows the test output when configured correctly', () => {
+    // arrange
+    process.env.NODE_ENV = 'production';
+
+    // act
+    const response = getApiKey();
+
+    // assert
+    expect(response).equals('the production API key');
+  });
+
+  it('shows unintended output when not configured', () => {
+    // act
+    const response = getApiKey();
+
+    // assert
+    expect(response).equals('the development API key');
+  });
+});


### PR DESCRIPTION
## A summary of your update
- create an example of source + test code which is aware of its environment.

## Results of `npm run lint`
john@jaw-ubuntu-vm:~/code/js-unit-test-examples$ npm run lint

> js-unit-test-examples@1.0.0 lint
> eslint ./

john@jaw-ubuntu-vm:~/code/js-unit-test-examples$ 
```

## Results of `npm run test:mocha` and `npm run test:jest`
```bash
john@jaw-ubuntu-vm:~/code/js-unit-test-examples$ npm run test:jest && npm run test:mocha

> js-unit-test-examples@1.0.0 test:jest
> jest

 PASS  test/common/logger.j.spec.js
 PASS  test/testAware.j.spec.js
 PASS  test/wait.j.spec.js
 PASS  test/common/throws.j.spec.js
 PASS  test/destructuring.j.spec.js
 PASS  test/selfInvoking.j.spec.js
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |                   
 src               |     100 |      100 |     100 |     100 |                   
  destructuring.js |     100 |      100 |     100 |     100 |                   
  selfInvoking.js  |     100 |      100 |     100 |     100 |                   
  testAware.js     |     100 |      100 |     100 |     100 |                   
  wait.js          |     100 |      100 |     100 |     100 |                   
 src/common        |     100 |      100 |     100 |     100 |                   
  logger.js        |     100 |      100 |     100 |     100 |                   
  throws.js        |     100 |      100 |     100 |     100 |                   
-------------------|---------|----------|---------|---------|-------------------

Test Suites: 6 passed, 6 total
Tests:       14 passed, 14 total
Snapshots:   0 total
Time:        0.598 s, estimated 1 s
Ran all test suites.

> js-unit-test-examples@1.0.0 test:mocha
> nyc mocha


  ✓ src/destructuring.js can mock the logger: 4ms
  ✓ src/selfInvoking.js calls throws with an error message: 1ms
  ✓ src/selfInvoking.js does not call `throws` additional times: 0ms
  ✓ src/common/throws.js throws asserts an error was thrown: 1ms
  ✓ src/testAware.js shows the test output when configured correctly: 1ms
  ✓ src/testAware.js shows unintended output when not configured: 0ms
  ✓ src/common/logger.js logger should call console.error with args: 3ms
  ✓ src/common/logger.js logger should call console.warn with args: 1ms
  ✓ src/common/logger.js logger should call console.log with args: 0ms
  ✓ src/common/logger.js logger should call console.debug with args: 0ms
  ✓ src/wait.js calls setTimeout with a time to wait: 3ms
  ✓ src/wait.js calls setTimeout with a default: 1ms

  12 passing (459ms)

-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |                   
 src               |     100 |      100 |     100 |     100 |                   
  destructuring.js |     100 |      100 |     100 |     100 |                   
  selfInvoking.js  |     100 |      100 |     100 |     100 |                   
  testAware.js     |     100 |      100 |     100 |     100 |                   
  wait.js          |     100 |      100 |     100 |     100 |                   
 src/common        |     100 |      100 |     100 |     100 |                   
  logger.js        |     100 |      100 |     100 |     100 |                   
  throws.js        |     100 |      100 |     100 |     100 |                   
-------------------|---------|----------|---------|---------|-------------------
john@jaw-ubuntu-vm:~/code/js-unit-test-examples$
```

